### PR TITLE
Revert package name to fix building

### DIFF
--- a/set_vcd_vm_extraconfig.go
+++ b/set_vcd_vm_extraconfig.go
@@ -1,4 +1,4 @@
-package set_vcd_vm_extraconfig
+package main
 
 import (
 	"flag"


### PR DESCRIPTION
A mixup on my end. So by setting package back to 'main', the application builds correctly with 'go build'.